### PR TITLE
Rediseña inventario para operar por compras/ventas trazables

### DIFF
--- a/app/api/alertas/route.ts
+++ b/app/api/alertas/route.ts
@@ -15,31 +15,27 @@ export async function GET() {
       .eq("id", empresaId)
       .single()
 
-    // Get products with low stock
-    const { data: productos, error } = await supabase
-      .from("producto")
-      .select("id, nombre, sku, stock, stock_minimo, id_categoria, categoria(nombre)")
+    const { data: bajosStock, error } = await supabase
+      .from("v_productos_bajo_stock")
+      .select("id, producto, sku, stock, stock_minimo, categoria, faltante")
       .eq("id_empresa", empresaId)
-      .eq("activo", true)
-      .gt("stock_minimo", 0)
 
     if (error) throw error
 
-    const bajosStock = (productos || []).filter(p => p.stock <= p.stock_minimo)
-
-    const alertas = bajosStock.map((p) => ({
+    const alertas = (bajosStock || []).map((p) => ({
       id: `alert-${p.id}`,
       tipo: p.stock === 0 ? "critical" : "warning",
       titulo: p.stock === 0 ? "Stock agotado" : "Stock bajo",
-      descripcion: p.stock === 0
-        ? "El producto ha llegado a 0. Se requiere reabastecimiento urgente."
-        : `Stock actual ${p.stock} por debajo del minimo (${p.stock_minimo}). Faltan ${p.stock_minimo - p.stock} unidades.`,
-      producto: p.nombre,
+      descripcion:
+        p.stock === 0
+          ? "El producto ha llegado a 0. Se requiere reabastecimiento urgente."
+          : `Stock actual ${p.stock} por debajo del minimo (${p.stock_minimo}). Faltan ${p.faltante} unidades.`,
+      producto: p.producto,
       sku: p.sku,
       stock: p.stock,
       stock_minimo: p.stock_minimo,
-      faltante: p.stock_minimo - p.stock,
-      categoria: (p.categoria as { nombre: string } | null)?.nombre || null,
+      faltante: p.faltante,
+      categoria: p.categoria || null,
       leida: false,
       fecha: new Date().toISOString(),
     }))
@@ -50,7 +46,7 @@ export async function GET() {
       criticas: alertas.filter((a) => a.tipo === "critical").length,
       advertencias: alertas.filter((a) => a.tipo === "warning").length,
       empresa: empresa?.nombre || "",
-      email: empresa?.email || user.email || "",
+      email: empresa?.email || "",
     })
   } catch (error) {
     console.error("[alertas GET]", error)
@@ -66,6 +62,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "No autenticado" }, { status: 401 })
     }
 
+    const empresaId = await getEmpresaId(supabase)
     const body = await request.json()
     if (body.action !== "send_email_alerts") {
       return NextResponse.json({ error: "Accion no reconocida" }, { status: 400 })
@@ -74,7 +71,7 @@ export async function POST(request: Request) {
     const { data: empresa } = await supabase
       .from("empresa")
       .select("nombre, email")
-      .eq("id", user.id)
+      .eq("id", empresaId)
       .single()
 
     const emailDestino = empresa?.email || user.email
@@ -82,21 +79,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "No hay email configurado" }, { status: 400 })
     }
 
-    // Get products with low stock
-    const { data: productos } = await supabase
-      .from("producto")
-      .select("nombre, sku, stock, stock_minimo, categoria(nombre)")
-      .eq("id_empresa", user.id)
-      .eq("activo", true)
-      .gt("stock_minimo", 0)
+    const { data: bajosStock } = await supabase
+      .from("v_productos_bajo_stock")
+      .select("producto, sku, stock, stock_minimo, categoria, faltante")
+      .eq("id_empresa", empresaId)
 
-    const bajosStock = (productos || []).filter(p => p.stock <= p.stock_minimo)
-
-    if (bajosStock.length === 0) {
+    if (!bajosStock || bajosStock.length === 0) {
       return NextResponse.json({ success: true, message: "No hay alertas de stock que enviar" })
     }
 
-    // Check if Resend is available
     const resendApiKey = process.env.RESEND_API_KEY
     if (!resendApiKey) {
       return NextResponse.json({
@@ -106,16 +97,18 @@ export async function POST(request: Request) {
       })
     }
 
-    // Send email using Resend
     const empresaNombre = empresa?.nombre || "Tu empresa"
-    const html = buildEmailHTML(empresaNombre, bajosStock.map(p => ({
-      producto: p.nombre,
-      sku: p.sku,
-      stock: p.stock,
-      stock_minimo: p.stock_minimo,
-      faltante: p.stock_minimo - p.stock,
-      categoria: (p.categoria as { nombre: string } | null)?.nombre || null,
-    })))
+    const html = buildEmailHTML(
+      empresaNombre,
+      bajosStock.map((p) => ({
+        producto: p.producto,
+        sku: p.sku,
+        stock: p.stock,
+        stock_minimo: p.stock_minimo,
+        faltante: p.faltante,
+        categoria: p.categoria || null,
+      }))
+    )
 
     const response = await fetch("https://api.resend.com/emails", {
       method: "POST",
@@ -124,7 +117,7 @@ export async function POST(request: Request) {
         Authorization: `Bearer ${resendApiKey}`,
       },
       body: JSON.stringify({
-        from: `Invora <onboarding@resend.dev>`,
+        from: "Invora <onboarding@resend.dev>",
         to: emailDestino,
         subject: `Alerta: ${bajosStock.length} producto${bajosStock.length !== 1 ? "s" : ""} con stock bajo`,
         html,
@@ -152,7 +145,9 @@ function buildEmailHTML(
   empresaNombre: string,
   productos: Array<{ producto: string; sku: string | null; stock: number; stock_minimo: number; faltante: number; categoria: string | null }>
 ) {
-  const rows = productos.map((p) => `
+  const rows = productos
+    .map(
+      (p) => `
     <tr style="border-bottom:1px solid #e5e7eb;">
       <td style="padding:10px 8px;font-weight:500;color:#111827;">${p.producto}</td>
       <td style="padding:10px 8px;color:#6b7280;">${p.sku || "—"}</td>
@@ -160,7 +155,9 @@ function buildEmailHTML(
       <td style="padding:10px 8px;text-align:center;font-weight:700;color:${p.stock === 0 ? "#dc2626" : "#d97706"};">${p.stock}</td>
       <td style="padding:10px 8px;text-align:center;color:#6b7280;">${p.stock_minimo}</td>
       <td style="padding:10px 8px;text-align:center;font-weight:700;color:#dc2626;">-${p.faltante}</td>
-    </tr>`).join("")
+    </tr>`
+    )
+    .join("")
 
   const criticos = productos.filter((p) => p.stock === 0).length
   const bajos = productos.filter((p) => p.stock > 0).length
@@ -192,11 +189,6 @@ function buildEmailHTML(
         </thead>
         <tbody>${rows}</tbody>
       </table>
-    </div>
-    <div style="background:#f9fafb;border-radius:0 0 12px 12px;padding:16px 32px;border-top:1px solid #e5e7eb;">
-      <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;">
-        Este correo fue generado automaticamente por <strong>Invora</strong> · Sistema de Gestion de Inventario
-      </p>
     </div>
   </div>
 </body></html>`

--- a/app/api/clientes/route.ts
+++ b/app/api/clientes/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { getEmpresaId } from "@/lib/supabase/empresa"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const { data, error } = await supabase
+      .from("cliente")
+      .select("id, nombre, apellido")
+      .eq("id_empresa", empresaId)
+      .eq("activo", true)
+      .order("nombre", { ascending: true })
+
+    if (error) throw error
+    return NextResponse.json({ clientes: data || [] })
+  } catch (error) {
+    console.error("[clientes GET]", error)
+    return NextResponse.json({ error: "Error al cargar clientes" }, { status: 500 })
+  }
+}

--- a/app/api/clientes/route.ts
+++ b/app/api/clientes/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
 
     const { data, error } = await supabase
       .from("cliente")
-      .select("id, nombre, apellido")
+      .select("id, nombre, apellido, correo, telefono")
       .eq("id_empresa", empresaId)
       .eq("activo", true)
       .order("nombre", { ascending: true })
@@ -21,5 +21,42 @@ export async function GET() {
   } catch (error) {
     console.error("[clientes GET]", error)
     return NextResponse.json({ error: "Error al cargar clientes" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+    const body = await request.json()
+
+    const nombre = (body.nombre as string | undefined)?.trim()
+    const apellido = (body.apellido as string | undefined)?.trim() || null
+    const correo = (body.correo as string | undefined)?.trim() || null
+    const telefono = (body.telefono as string | undefined)?.trim() || null
+
+    if (!nombre) {
+      return NextResponse.json({ error: "El nombre del cliente es requerido" }, { status: 400 })
+    }
+
+    const { data, error } = await supabase
+      .from("cliente")
+      .insert({
+        id_empresa: empresaId,
+        nombre,
+        apellido,
+        correo,
+        telefono,
+      })
+      .select("id, nombre, apellido, correo, telefono")
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json({ cliente: data, success: true })
+  } catch (error) {
+    console.error("[clientes POST]", error)
+    const message = error instanceof Error ? error.message : "Error al crear cliente"
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/app/api/compras/route.ts
+++ b/app/api/compras/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { EmpresaNotConfiguredError, UserNotAuthenticatedError, getEmpresaId } from "@/lib/supabase/empresa"
+
+export const dynamic = "force-dynamic"
+
+type CompraItem = {
+  id_producto: string
+  cantidad: number
+  precio_unitario: number
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const { data, error } = await supabase
+      .from("compra")
+      .select("id, numero, estado, monto_total, creado_en, proveedor:proveedor(nombre), compra_detalle(cantidad)")
+      .eq("id_empresa", empresaId)
+      .order("creado_en", { ascending: false })
+      .limit(20)
+
+    if (error) throw error
+
+    return NextResponse.json({ compras: data || [] })
+  } catch (error) {
+    console.error("[compras GET]", error)
+    if (error instanceof UserNotAuthenticatedError) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 })
+    }
+    if (error instanceof EmpresaNotConfiguredError) {
+      return NextResponse.json({ error: "Empresa no configurada", needsOnboarding: true }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Error al cargar compras" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const body = await request.json()
+    const idProveedor = body.id_proveedor as string
+    const items = (body.items || []) as CompraItem[]
+    const notas = (body.notas as string | undefined)?.trim() || null
+
+    if (!idProveedor) {
+      return NextResponse.json({ error: "La compra requiere un proveedor" }, { status: 400 })
+    }
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: "La compra debe incluir al menos un producto" }, { status: 400 })
+    }
+
+    const productIds = items.map((item) => item.id_producto)
+    const { data: productos, error: productosError } = await supabase
+      .from("producto")
+      .select("id")
+      .eq("id_empresa", empresaId)
+      .in("id", productIds)
+
+    if (productosError) throw productosError
+
+    if ((productos || []).length !== productIds.length) {
+      return NextResponse.json({ error: "Uno o más productos no pertenecen a tu empresa" }, { status: 400 })
+    }
+
+    const { data: proveedor, error: proveedorError } = await supabase
+      .from("proveedor")
+      .select("id")
+      .eq("id", idProveedor)
+      .eq("id_empresa", empresaId)
+      .single()
+
+    if (proveedorError || !proveedor) {
+      return NextResponse.json({ error: "Proveedor no encontrado" }, { status: 404 })
+    }
+
+    const { data: compra, error: compraError } = await supabase
+      .from("compra")
+      .insert({
+        id_empresa: empresaId,
+        id_proveedor: idProveedor,
+        estado: "recibida",
+        notas,
+      })
+      .select("id")
+      .single()
+
+    if (compraError || !compra) throw compraError
+
+    const detalles = items.map((item) => ({
+      id_compra: compra.id,
+      id_producto: item.id_producto,
+      cantidad: Number(item.cantidad),
+      precio_unitario: Number(item.precio_unitario),
+    }))
+
+    const { error: detalleError } = await supabase.from("compra_detalle").insert(detalles)
+    if (detalleError) throw detalleError
+
+    const relaciones = items.map((item) => ({
+      id_producto: item.id_producto,
+      id_proveedor: idProveedor,
+      precio_compra: Number(item.precio_unitario),
+      es_principal: false,
+    }))
+
+    await supabase
+      .from("producto_proveedor")
+      .upsert(relaciones, { onConflict: "id_producto,id_proveedor" })
+
+    return NextResponse.json({ success: true, id_compra: compra.id })
+  } catch (error) {
+    console.error("[compras POST]", error)
+    const message = error instanceof Error ? error.message : "Error al registrar compra"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -9,7 +9,6 @@ export async function GET() {
     const supabase = await createClient()
     const empresaId = await getEmpresaId(supabase)
 
-    // Get all productos for the empresa
     const { data: productos, error: prodError } = await supabase
       .from("producto")
       .select("id, nombre, stock, stock_minimo, precio_costo, activo")
@@ -18,16 +17,18 @@ export async function GET() {
     if (prodError) throw prodError
 
     const totalProductos = productos?.length || 0
-    const valorInventario = (productos || []).reduce(
-      (sum, p) => sum + (p.stock * (p.precio_costo || 0)),
-      0
-    )
-    const lowStockProducts = (productos || []).filter(
-      (p) => p.activo && p.stock <= p.stock_minimo && p.stock_minimo > 0
-    )
-    const alertasActivas = lowStockProducts.length
+    const valorInventario = (productos || []).reduce((sum, p) => sum + p.stock * (p.precio_costo || 0), 0)
 
-    // Get recent movements with product info
+    const { data: lowStockProducts, error: lowStockError } = await supabase
+      .from("v_productos_bajo_stock")
+      .select("id, producto, sku, stock, stock_minimo, categoria, faltante")
+      .eq("id_empresa", empresaId)
+      .limit(5)
+
+    if (lowStockError) throw lowStockError
+
+    const alertasActivas = lowStockProducts?.length || 0
+
     const { data: rawMovements, error: movError } = await supabase
       .from("v_historial_inventario")
       .select("id, tipo, cantidad, creado_en, producto")
@@ -37,22 +38,12 @@ export async function GET() {
 
     if (movError) throw movError
 
-    const recentMovements = (rawMovements || []).map((m) => ({
-      id: m.id,
-      tipo: m.tipo,
-      cantidad: m.cantidad,
-      creado_en: m.creado_en,
-      producto: m.producto,
-    }))
-
-    // Get movements today count
     const today = new Date()
     today.setHours(0, 0, 0, 0)
-    const movimientosHoy = recentMovements.filter(
-      (m) => new Date(m.creado_en) >= today
-    ).length
 
-    // Get categories data with product counts
+    const recentMovements = rawMovements || []
+    const movimientosHoy = recentMovements.filter((m) => new Date(m.creado_en) >= today).length
+
     const { data: productosConCategoria, error: catError } = await supabase
       .from("producto")
       .select("id_categoria, categoria(nombre)")
@@ -61,10 +52,10 @@ export async function GET() {
 
     if (catError) throw catError
 
-    // Group products by category
     const categoryMap = new Map<string, number>()
     ;(productosConCategoria || []).forEach((p) => {
-      const catName = (p.categoria as { nombre: string } | null)?.nombre || "Sin categoria"
+      const categoria = p.categoria as { nombre: string }[] | { nombre: string } | null
+      const catName = Array.isArray(categoria) ? categoria[0]?.nombre : categoria?.nombre || "Sin categoria"
       categoryMap.set(catName, (categoryMap.get(catName) || 0) + 1)
     })
 
@@ -72,12 +63,11 @@ export async function GET() {
       .map(([categoria, cantidad]) => ({ categoria, cantidad }))
       .sort((a, b) => b.cantidad - a.cantidad)
 
-    // Get monthly trend for the last 6 months
     const sixMonthsAgo = new Date()
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
 
     const { data: trendMovements, error: trendError } = await supabase
-      .from("movimiento_inventario")
+      .from("v_historial_inventario")
       .select("tipo, cantidad, creado_en")
       .eq("id_empresa", empresaId)
       .gte("creado_en", sixMonthsAgo.toISOString())
@@ -85,21 +75,15 @@ export async function GET() {
 
     if (trendError) throw trendError
 
-    // Group by month
     const monthMap = new Map<string, { mes: string; entradas: number; salidas: number }>()
     ;(trendMovements || []).forEach((m) => {
       const d = new Date(m.creado_en)
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
       const mesLabel = d.toLocaleDateString("es-CR", { month: "short" })
-      if (!monthMap.has(key)) {
-        monthMap.set(key, { mes: mesLabel, entradas: 0, salidas: 0 })
-      }
+      if (!monthMap.has(key)) monthMap.set(key, { mes: mesLabel, entradas: 0, salidas: 0 })
       const entry = monthMap.get(key)!
-      if (["entrada", "ajuste_positivo", "devolucion_venta"].includes(m.tipo)) {
-        entry.entradas += m.cantidad
-      } else {
-        entry.salidas += m.cantidad
-      }
+      if (["entrada", "ajuste_positivo", "devolucion_venta"].includes(m.tipo)) entry.entradas += m.cantidad
+      else entry.salidas += m.cantidad
     })
 
     const monthlyTrend = Array.from(monthMap.entries())
@@ -107,19 +91,14 @@ export async function GET() {
       .map(([, v]) => v)
 
     return NextResponse.json({
-      stats: {
-        totalProductos,
-        valorInventario,
-        movimientosHoy,
-        alertasActivas,
-      },
-      recentMovements: recentMovements || [],
-      lowStockProducts: lowStockProducts.slice(0, 5),
+      stats: { totalProductos, valorInventario, movimientosHoy, alertasActivas },
+      recentMovements,
+      lowStockProducts: lowStockProducts || [],
       categoryData: categoryData.slice(0, 5),
       monthlyTrend,
     })
   } catch (error) {
-    console.error("[v0] Dashboard API error:", error)
+    console.error("[dashboard GET]", error)
     if (error instanceof UserNotAuthenticatedError) {
       return NextResponse.json({ error: "No autenticado" }, { status: 401 })
     }

--- a/app/api/movimientos/route.ts
+++ b/app/api/movimientos/route.ts
@@ -14,7 +14,6 @@ export async function GET(request: Request) {
     const periodo = searchParams.get("periodo") || "30d"
     const exportCsv = searchParams.get("export") === "csv"
 
-    // Calculate date range
     let fechaDesde: Date | null = null
     const now = new Date()
     if (periodo === "1d") {
@@ -30,7 +29,7 @@ export async function GET(request: Request) {
 
     let query = supabase
       .from("v_historial_inventario")
-      .select("id, creado_en, producto, sku, tipo, cantidad, stock_antes, stock_despues, motivo")
+      .select("id, creado_en, producto, sku, tipo, cantidad, stock_antes, stock_despues, motivo, id_venta, id_compra")
       .eq("id_empresa", empresaId)
       .order("creado_en", { ascending: false })
 
@@ -52,7 +51,7 @@ export async function GET(request: Request) {
     const data = movimientos || []
 
     if (exportCsv) {
-      const headers = ["ID", "Fecha", "Producto", "SKU", "Tipo", "Cantidad", "Stock Antes", "Stock Despues", "Motivo"]
+      const headers = ["ID", "Fecha", "Producto", "SKU", "Tipo", "Cantidad", "Stock Antes", "Stock Despues", "Documento", "Motivo"]
       const rows = data.map((m) => [
         m.id,
         new Date(m.creado_en).toLocaleString("es-CR"),
@@ -62,6 +61,7 @@ export async function GET(request: Request) {
         m.cantidad,
         m.stock_antes,
         m.stock_despues,
+        m.id_venta ? `VENTA:${m.id_venta}` : m.id_compra ? `COMPRA:${m.id_compra}` : "",
         m.motivo || "",
       ])
       const csv = [headers, ...rows].map((r) => r.join(",")).join("\n")
@@ -73,7 +73,6 @@ export async function GET(request: Request) {
       })
     }
 
-    // Summary stats
     const entradas = data
       .filter((m) => ["entrada", "ajuste_positivo", "devolucion_venta"].includes(m.tipo))
       .reduce((s, m) => s + m.cantidad, 0)
@@ -97,76 +96,11 @@ export async function GET(request: Request) {
   }
 }
 
-export async function POST(request: Request) {
-  try {
-    const supabase = await createClient()
-    const empresaId = await getEmpresaId(supabase)
-
-    const body = await request.json()
-    const { id_producto, tipo, cantidad, motivo } = body
-
-    if (!id_producto || !tipo || !cantidad) {
-      return NextResponse.json({ error: "Producto, tipo y cantidad son requeridos" }, { status: 400 })
-    }
-
-    const cantidadInt = parseInt(cantidad)
-    if (isNaN(cantidadInt) || cantidadInt <= 0) {
-      return NextResponse.json({ error: "La cantidad debe ser un numero positivo" }, { status: 400 })
-    }
-
-    // Get current stock
-    const { data: producto, error: prodError } = await supabase
-      .from("producto")
-      .select("id, stock, nombre")
-      .eq("id", id_producto)
-      .eq("id_empresa", empresaId)
-      .single()
-
-    if (prodError || !producto) {
-      return NextResponse.json({ error: "Producto no encontrado" }, { status: 404 })
-    }
-
-    const esEntrada = ["entrada", "ajuste_positivo", "devolucion_venta"].includes(tipo)
-    const esSalida = ["salida", "ajuste_negativo", "devolucion_compra"].includes(tipo)
-
-    const stockActual = producto.stock
-    const nuevoStock = esEntrada ? stockActual + cantidadInt : stockActual - cantidadInt
-
-    if (esSalida && nuevoStock < 0) {
-      return NextResponse.json({
-        error: `Stock insuficiente. Stock actual: ${stockActual}, cantidad solicitada: ${cantidadInt}`,
-      }, { status: 400 })
-    }
-
-    // Update stock
-    const { error: updateError } = await supabase
-      .from("producto")
-      .update({ stock: nuevoStock })
-      .eq("id", id_producto)
-
-    if (updateError) throw updateError
-
-    // Record movement
-    const { data: movimiento, error: movError } = await supabase
-      .from("movimiento_inventario")
-      .insert({
-        id_empresa: empresaId,
-        id_producto,
-        tipo,
-        cantidad: cantidadInt,
-        stock_antes: stockActual,
-        stock_despues: nuevoStock,
-        motivo: motivo?.trim() || null,
-      })
-      .select("id")
-      .single()
-
-    if (movError) throw movError
-
-    return NextResponse.json({ success: true, movimiento, nuevoStock })
-  } catch (error) {
-    console.error("[movimientos POST]", error)
-    const msg = error instanceof Error ? error.message : "Error al registrar movimiento"
-    return NextResponse.json({ error: msg }, { status: 500 })
-  }
+export async function POST() {
+  return NextResponse.json(
+    {
+      error: "Los movimientos manuales están deshabilitados. Registra compras o ventas para afectar inventario.",
+    },
+    { status: 405 }
+  )
 }

--- a/app/api/productos/route.ts
+++ b/app/api/productos/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
     const empresaId = await getEmpresaId(supabase)
 
     const body = await request.json()
-    const { nombre, sku, id_categoria, stock, stock_minimo, precio_costo, precio_venta, descripcion } = body
+    const { nombre, sku, id_categoria, stock_minimo, precio_costo, precio_venta, descripcion } = body
 
     if (!nombre?.trim()) {
       return NextResponse.json({ error: "El nombre es requerido" }, { status: 400 })
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
     const insertData: Record<string, unknown> = {
       id_empresa: empresaId,
       nombre: nombre.trim(),
-      stock: parseInt(stock) || 0,
+      stock: 0,
       stock_minimo: parseInt(stock_minimo) || 0,
       precio_costo: parseFloat(precio_costo) || 0,
       precio_venta: parseFloat(precio_venta) || 0,
@@ -74,20 +74,6 @@ export async function POST(request: Request) {
 
     if (error) throw error
 
-    // Record initial stock movement
-    if (parseInt(stock) > 0) {
-      await supabase
-        .from("movimiento_inventario")
-        .insert({
-          id_empresa: empresaId,
-          id_producto: producto.id,
-          tipo: "entrada",
-          cantidad: parseInt(stock),
-          stock_antes: 0,
-          stock_despues: parseInt(stock),
-          motivo: "Stock inicial al crear producto",
-        })
-    }
 
     return NextResponse.json({ producto, success: true })
   } catch (error) {

--- a/app/api/productos/route.ts
+++ b/app/api/productos/route.ts
@@ -48,10 +48,26 @@ export async function POST(request: Request) {
     const empresaId = await getEmpresaId(supabase)
 
     const body = await request.json()
-    const { nombre, sku, id_categoria, stock_minimo, precio_costo, precio_venta, descripcion } = body
+    const {
+      nombre,
+      sku,
+      id_categoria,
+      stock_minimo,
+      precio_costo,
+      precio_venta,
+      descripcion,
+      cantidad_inicial,
+      id_proveedor,
+      precio_compra,
+    } = body
 
     if (!nombre?.trim()) {
       return NextResponse.json({ error: "El nombre es requerido" }, { status: 400 })
+    }
+
+    const cantidadInicial = parseInt(cantidad_inicial) || 0
+    if (cantidadInicial > 0 && !id_proveedor) {
+      return NextResponse.json({ error: "Para stock inicial debes seleccionar un proveedor" }, { status: 400 })
     }
 
     const insertData: Record<string, unknown> = {
@@ -72,8 +88,56 @@ export async function POST(request: Request) {
       .select("id, nombre, sku, stock, stock_minimo, precio_costo, precio_venta, activo, id_categoria, categoria(id, nombre)")
       .single()
 
-    if (error) throw error
+    if (error || !producto) throw error
 
+    if (cantidadInicial > 0) {
+      const { data: proveedor, error: proveedorError } = await supabase
+        .from("proveedor")
+        .select("id")
+        .eq("id", id_proveedor)
+        .eq("id_empresa", empresaId)
+        .single()
+
+      if (proveedorError || !proveedor) {
+        return NextResponse.json({ error: "Proveedor no encontrado" }, { status: 404 })
+      }
+
+      const precioCompra = parseFloat(precio_compra) || parseFloat(precio_costo) || 0
+
+      const { data: compra, error: compraError } = await supabase
+        .from("compra")
+        .insert({
+          id_empresa: empresaId,
+          id_proveedor,
+          estado: "recibida",
+          notas: `Compra inicial al crear producto ${producto.nombre}`,
+        })
+        .select("id")
+        .single()
+
+      if (compraError || !compra) throw compraError
+
+      const { error: detalleError } = await supabase.from("compra_detalle").insert({
+        id_compra: compra.id,
+        id_producto: producto.id,
+        cantidad: cantidadInicial,
+        precio_unitario: precioCompra,
+      })
+
+      if (detalleError) throw detalleError
+
+      await supabase
+        .from("producto_proveedor")
+        .upsert(
+          {
+            id_producto: producto.id,
+            id_proveedor,
+            precio_compra: precioCompra,
+            es_principal: true,
+          },
+          { onConflict: "id_producto,id_proveedor" }
+        )
+    }
 
     return NextResponse.json({ producto, success: true })
   } catch (error) {

--- a/app/api/proveedores/route.ts
+++ b/app/api/proveedores/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { getEmpresaId } from "@/lib/supabase/empresa"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const { data, error } = await supabase
+      .from("proveedor")
+      .select("id, nombre")
+      .eq("id_empresa", empresaId)
+      .eq("activo", true)
+      .order("nombre", { ascending: true })
+
+    if (error) throw error
+    return NextResponse.json({ proveedores: data || [] })
+  } catch (error) {
+    console.error("[proveedores GET]", error)
+    return NextResponse.json({ error: "Error al cargar proveedores" }, { status: 500 })
+  }
+}

--- a/app/api/proveedores/route.ts
+++ b/app/api/proveedores/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
 
     const { data, error } = await supabase
       .from("proveedor")
-      .select("id, nombre")
+      .select("id, nombre, correo, telefono")
       .eq("id_empresa", empresaId)
       .eq("activo", true)
       .order("nombre", { ascending: true })
@@ -21,5 +21,40 @@ export async function GET() {
   } catch (error) {
     console.error("[proveedores GET]", error)
     return NextResponse.json({ error: "Error al cargar proveedores" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+    const body = await request.json()
+
+    const nombre = (body.nombre as string | undefined)?.trim()
+    const correo = (body.correo as string | undefined)?.trim() || null
+    const telefono = (body.telefono as string | undefined)?.trim() || null
+
+    if (!nombre) {
+      return NextResponse.json({ error: "El nombre del proveedor es requerido" }, { status: 400 })
+    }
+
+    const { data, error } = await supabase
+      .from("proveedor")
+      .insert({
+        id_empresa: empresaId,
+        nombre,
+        correo,
+        telefono,
+      })
+      .select("id, nombre, correo, telefono")
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json({ proveedor: data, success: true })
+  } catch (error) {
+    console.error("[proveedores POST]", error)
+    const message = error instanceof Error ? error.message : "Error al crear proveedor"
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/app/api/reportes/route.ts
+++ b/app/api/reportes/route.ts
@@ -11,14 +11,14 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url)
     const periodo = searchParams.get("periodo") || "7m"
-
-    // Calculate how many months to look back
     const mesesAtras = periodo === "30d" ? 1 : periodo === "3m" ? 3 : periodo === "7m" ? 7 : 12
 
-    // 1. KPI: total inventory value, active SKUs
+    const fechaDesde = new Date()
+    fechaDesde.setMonth(fechaDesde.getMonth() - mesesAtras)
+
     const { data: productos } = await supabase
       .from("producto")
-      .select("id, stock, precio_costo, precio_venta, activo")
+      .select("id, stock, precio_costo, activo")
       .eq("id_empresa", empresaId)
       .eq("activo", true)
 
@@ -26,37 +26,43 @@ export async function GET(request: Request) {
     const valorInventario = prods.reduce((s, p) => s + p.stock * Number(p.precio_costo), 0)
     const skusActivos = prods.length
 
-    // 2. Monthly trend - movements grouped by month
-    const fechaDesde = new Date()
-    fechaDesde.setMonth(fechaDesde.getMonth() - mesesAtras)
+    const { data: resumenVentas } = await supabase
+      .from("v_resumen_ventas_mensual")
+      .select("mes, total_ventas")
+      .eq("id_empresa", empresaId)
+      .gte("mes", fechaDesde.toISOString())
+      .order("mes", { ascending: true })
 
     const { data: movimientos } = await supabase
-      .from("movimiento_inventario")
+      .from("v_historial_inventario")
       .select("tipo, cantidad, creado_en")
       .eq("id_empresa", empresaId)
       .gte("creado_en", fechaDesde.toISOString())
       .order("creado_en", { ascending: true })
 
-    // Group by month
-    const monthMap = new Map<string, { mes: string; entradas: number; salidas: number; valorMes: number }>()
+    const monthMap = new Map<string, { mes: string; entradas: number; salidas: number; ventas: number }>()
     ;(movimientos || []).forEach((m) => {
       const d = new Date(m.creado_en)
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
       const mesLabel = d.toLocaleDateString("es-CR", { month: "short", year: "2-digit" })
-      if (!monthMap.has(key)) monthMap.set(key, { mes: mesLabel, entradas: 0, salidas: 0, valorMes: 0 })
+      if (!monthMap.has(key)) monthMap.set(key, { mes: mesLabel, entradas: 0, salidas: 0, ventas: 0 })
       const entry = monthMap.get(key)!
-      if (["entrada", "ajuste_positivo", "devolucion_venta"].includes(m.tipo)) {
-        entry.entradas += m.cantidad
-      } else {
-        entry.salidas += m.cantidad
-      }
+      if (["entrada", "ajuste_positivo", "devolucion_venta"].includes(m.tipo)) entry.entradas += m.cantidad
+      else entry.salidas += m.cantidad
+    })
+
+    ;(resumenVentas || []).forEach((rv) => {
+      const d = new Date(rv.mes)
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
+      const mesLabel = d.toLocaleDateString("es-CR", { month: "short", year: "2-digit" })
+      if (!monthMap.has(key)) monthMap.set(key, { mes: mesLabel, entradas: 0, salidas: 0, ventas: 0 })
+      monthMap.get(key)!.ventas = Number(rv.total_ventas || 0)
     })
 
     const monthlyTrend = Array.from(monthMap.entries())
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([, v]) => v)
 
-    // 3. Category distribution by product count and value
     const { data: productosCat } = await supabase
       .from("producto")
       .select("stock, precio_costo, id_categoria, categoria(nombre)")
@@ -65,7 +71,8 @@ export async function GET(request: Request) {
 
     const catMap = new Map<string, { name: string; value: number; valorTotal: number }>()
     ;(productosCat || []).forEach((p) => {
-      const catName = (p.categoria as { nombre: string } | null)?.nombre || "Sin categoria"
+      const categoria = p.categoria as { nombre: string }[] | { nombre: string } | null
+      const catName = Array.isArray(categoria) ? categoria[0]?.nombre : categoria?.nombre || "Sin categoria"
       if (!catMap.has(catName)) catMap.set(catName, { name: catName, value: 0, valorTotal: 0 })
       const c = catMap.get(catName)!
       c.value += 1
@@ -77,36 +84,19 @@ export async function GET(request: Request) {
     const categoryDistribution = Array.from(catMap.values())
       .sort((a, b) => b.value - a.value)
       .slice(0, 5)
-      .map((c, i) => ({
-        ...c,
-        percentage: totalProductos > 0 ? Math.round((c.value / totalProductos) * 100) : 0,
-        color: colors[i % colors.length],
-      }))
+      .map((c, i) => ({ ...c, percentage: totalProductos > 0 ? Math.round((c.value / totalProductos) * 100) : 0, color: colors[i % colors.length] }))
 
-    // 4. Top products by movement (salidas)
-    const { data: topMovs } = await supabase
-      .from("movimiento_inventario")
-      .select("id_producto, cantidad, tipo, producto:producto(nombre, sku)")
+    const { data: topVendidos } = await supabase
+      .from("v_productos_mas_vendidos")
+      .select("id_empresa, producto, unidades_vendidas")
       .eq("id_empresa", empresaId)
-      .in("tipo", ["salida", "ajuste_negativo"])
-      .gte("creado_en", fechaDesde.toISOString())
+      .limit(5)
 
-    const prodMovMap = new Map<string, { nombre: string; salidas: number }>()
-    ;(topMovs || []).forEach((m) => {
-      const prodInfo = m.producto as { nombre: string; sku: string } | null
-      const nombre = prodInfo?.nombre || "Desconocido"
-      if (!prodMovMap.has(m.id_producto)) {
-        prodMovMap.set(m.id_producto, { nombre, salidas: 0 })
-      }
-      prodMovMap.get(m.id_producto)!.salidas += m.cantidad
-    })
+    const topProducts = (topVendidos || []).map((p) => ({
+      nombre: p.producto.length > 15 ? `${p.producto.substring(0, 15)}...` : p.producto,
+      salidas: Number(p.unidades_vendidas),
+    }))
 
-    const topProducts = Array.from(prodMovMap.values())
-      .sort((a, b) => b.salidas - a.salidas)
-      .slice(0, 5)
-      .map((p) => ({ nombre: p.nombre.length > 15 ? p.nombre.substring(0, 15) + "..." : p.nombre, salidas: p.salidas }))
-
-    // 5. Rotation rate: total salidas / avg stock
     const totalSalidas = (movimientos || [])
       .filter((m) => ["salida", "ajuste_negativo"].includes(m.tipo))
       .reduce((s, m) => s + m.cantidad, 0)
@@ -114,11 +104,7 @@ export async function GET(request: Request) {
     const rotacion = avgStock > 0 ? (totalSalidas / avgStock).toFixed(1) : "0.0"
 
     return NextResponse.json({
-      kpis: {
-        valorInventario,
-        skusActivos,
-        rotacion: `${rotacion}x / mes`,
-      },
+      kpis: { valorInventario, skusActivos, rotacion: `${rotacion}x / mes` },
       monthlyTrend,
       categoryDistribution,
       topProducts,

--- a/app/api/ventas/route.ts
+++ b/app/api/ventas/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { EmpresaNotConfiguredError, UserNotAuthenticatedError, getEmpresaId } from "@/lib/supabase/empresa"
+
+export const dynamic = "force-dynamic"
+
+type VentaItem = {
+  id_producto: string
+  cantidad: number
+  precio_unitario: number
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const { data, error } = await supabase
+      .from("venta")
+      .select("id, numero, estado, monto_total, creado_en, cliente:cliente(nombre, apellido), venta_detalle(cantidad)")
+      .eq("id_empresa", empresaId)
+      .order("creado_en", { ascending: false })
+      .limit(20)
+
+    if (error) throw error
+
+    return NextResponse.json({ ventas: data || [] })
+  } catch (error) {
+    console.error("[ventas GET]", error)
+    if (error instanceof UserNotAuthenticatedError) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 })
+    }
+    if (error instanceof EmpresaNotConfiguredError) {
+      return NextResponse.json({ error: "Empresa no configurada", needsOnboarding: true }, { status: 403 })
+    }
+    return NextResponse.json({ error: "Error al cargar ventas" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const empresaId = await getEmpresaId(supabase)
+
+    const body = await request.json()
+    const idCliente = body.id_cliente as string
+    const items = (body.items || []) as VentaItem[]
+    const notas = (body.notas as string | undefined)?.trim() || null
+
+    if (!idCliente) {
+      return NextResponse.json({ error: "La venta requiere un cliente" }, { status: 400 })
+    }
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: "La venta debe incluir al menos un producto" }, { status: 400 })
+    }
+
+    const productIds = items.map((item) => item.id_producto)
+    const { data: productos, error: productosError } = await supabase
+      .from("producto")
+      .select("id")
+      .eq("id_empresa", empresaId)
+      .in("id", productIds)
+
+    if (productosError) throw productosError
+
+    if ((productos || []).length !== productIds.length) {
+      return NextResponse.json({ error: "Uno o más productos no pertenecen a tu empresa" }, { status: 400 })
+    }
+
+    const { data: cliente, error: clienteError } = await supabase
+      .from("cliente")
+      .select("id")
+      .eq("id", idCliente)
+      .eq("id_empresa", empresaId)
+      .single()
+
+    if (clienteError || !cliente) {
+      return NextResponse.json({ error: "Cliente no encontrado" }, { status: 404 })
+    }
+
+    const { data: venta, error: ventaError } = await supabase
+      .from("venta")
+      .insert({
+        id_empresa: empresaId,
+        id_cliente: idCliente,
+        estado: "completada",
+        notas,
+      })
+      .select("id")
+      .single()
+
+    if (ventaError || !venta) throw ventaError
+
+    const detalles = items.map((item) => ({
+      id_venta: venta.id,
+      id_producto: item.id_producto,
+      cantidad: Number(item.cantidad),
+      precio_unitario: Number(item.precio_unitario),
+    }))
+
+    const { error: detalleError } = await supabase.from("venta_detalle").insert(detalles)
+    if (detalleError) throw detalleError
+
+    return NextResponse.json({ success: true, id_venta: venta.id })
+  } catch (error) {
+    console.error("[ventas POST]", error)
+    const message = error instanceof Error ? error.message : "Error al registrar venta"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/dashboard/clientes/page.tsx
+++ b/app/dashboard/clientes/page.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useState } from "react"
+import useSWR, { mutate } from "swr"
+import { Users, Loader2, AlertTriangle, Plus } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+export default function ClientesPage() {
+  const { data, error, isLoading } = useSWR("/api/clientes", fetcher)
+  const [saving, setSaving] = useState(false)
+  const [form, setForm] = useState({ nombre: "", apellido: "", correo: "", telefono: "" })
+
+  const clientes = data?.clientes || []
+
+  const handleSave = async () => {
+    if (!form.nombre.trim()) return
+    setSaving(true)
+    try {
+      const res = await fetch("/api/clientes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      })
+      if (res.ok) {
+        setForm({ nombre: "", apellido: "", correo: "", telefono: "" })
+        mutate("/api/clientes")
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (isLoading) return <div className="flex items-center justify-center min-h-[60vh]"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>
+  if (error || data?.error) return <div className="flex items-center justify-center min-h-[60vh]"><AlertTriangle className="h-8 w-8 text-amber-400" /></div>
+
+  return (
+    <div className="flex flex-col gap-6 animate-fade-in">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Clientes</h1>
+        <p className="text-sm text-muted-foreground mt-1">Gestiona tus clientes para registrar ventas.</p>
+      </div>
+
+      <Card className="glass-card border-border/30">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2"><Plus className="h-4 w-4 text-primary" />Nuevo Cliente</CardTitle>
+          <CardDescription>Completa los datos básicos del cliente.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          <div className="grid md:grid-cols-2 gap-3">
+            <Input placeholder="Nombre" value={form.nombre} onChange={(e) => setForm({ ...form, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
+            <Input placeholder="Apellido" value={form.apellido} onChange={(e) => setForm({ ...form, apellido: e.target.value })} className="bg-secondary/50 border-border/30" />
+          </div>
+          <div className="grid md:grid-cols-2 gap-3">
+            <Input placeholder="Correo" value={form.correo} onChange={(e) => setForm({ ...form, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
+            <Input placeholder="Teléfono" value={form.telefono} onChange={(e) => setForm({ ...form, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
+          </div>
+          <Button onClick={handleSave} disabled={saving || !form.nombre.trim()} className="w-fit">
+            {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            Guardar Cliente
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="glass-card border-border/30">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2"><Users className="h-4 w-4 text-primary" />Listado de Clientes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {clientes.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Aún no hay clientes registrados.</p>
+            ) : clientes.map((c: { id: string; nombre: string; apellido?: string; correo?: string; telefono?: string }) => (
+              <div key={c.id} className="rounded-md border border-border/30 p-3 text-sm">
+                <p className="font-medium">{c.nombre} {c.apellido || ""}</p>
+                <p className="text-muted-foreground">{c.correo || "Sin correo"} · {c.telefono || "Sin teléfono"}</p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/configuracion/page.tsx
+++ b/app/dashboard/configuracion/page.tsx
@@ -9,8 +9,6 @@ import {
   Loader2,
   AlertTriangle,
   CheckCircle,
-  Users,
-  Truck,
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -27,8 +25,6 @@ export default function ConfiguracionPage() {
   const [saveStatus, setSaveStatus] = useState<{ success: boolean; message: string } | null>(null)
 
   const { data, error, isLoading } = useSWR("/api/empresa", fetcher)
-  const { data: clientesData } = useSWR("/api/clientes", fetcher)
-  const { data: proveedoresData } = useSWR("/api/proveedores", fetcher)
 
   const [formData, setFormData] = useState({
     nombre: "",
@@ -36,9 +32,6 @@ export default function ConfiguracionPage() {
     direccion: "",
     id_fiscal: "",
   })
-  const [clienteForm, setClienteForm] = useState({ nombre: "", apellido: "", correo: "", telefono: "" })
-  const [proveedorForm, setProveedorForm] = useState({ nombre: "", correo: "", telefono: "" })
-  const [savingTerceros, setSavingTerceros] = useState(false)
 
   useEffect(() => {
     if (data?.empresa) {
@@ -82,46 +75,6 @@ export default function ConfiguracionPage() {
     }
   }
 
-
-  const handleAddCliente = async () => {
-    if (!clienteForm.nombre.trim()) return
-    setSavingTerceros(true)
-    try {
-      const res = await fetch("/api/clientes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(clienteForm),
-      })
-      if (res.ok) {
-        setClienteForm({ nombre: "", apellido: "", correo: "", telefono: "" })
-        mutate("/api/clientes")
-      }
-    } finally {
-      setSavingTerceros(false)
-    }
-  }
-
-  const handleAddProveedor = async () => {
-    if (!proveedorForm.nombre.trim()) return
-    setSavingTerceros(true)
-    try {
-      const res = await fetch("/api/proveedores", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(proveedorForm),
-      })
-      if (res.ok) {
-        setProveedorForm({ nombre: "", correo: "", telefono: "" })
-        mutate("/api/proveedores")
-      }
-    } finally {
-      setSavingTerceros(false)
-    }
-  }
-
-  const clientes = clientesData?.clientes || []
-  const proveedores = proveedoresData?.proveedores || []
-
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
@@ -146,7 +99,6 @@ export default function ConfiguracionPage() {
 
   return (
     <div className="flex flex-col gap-6 animate-fade-in">
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-foreground">Configuracion</h1>
         <p className="text-sm text-muted-foreground mt-1">
@@ -167,10 +119,6 @@ export default function ConfiguracionPage() {
           <TabsTrigger value="seguridad" className="text-xs gap-1.5 data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
             <Shield className="h-3.5 w-3.5" />
             Seguridad
-          </TabsTrigger>
-          <TabsTrigger value="terceros" className="text-xs gap-1.5 data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
-            <Users className="h-3.5 w-3.5" />
-            Clientes/Proveedores
           </TabsTrigger>
         </TabsList>
 
@@ -326,72 +274,6 @@ export default function ConfiguracionPage() {
               </div>
             </CardContent>
           </Card>
-        </TabsContent>
-
-
-        <TabsContent value="terceros" className="mt-6">
-          <div className="grid lg:grid-cols-2 gap-6">
-            <Card className="glass-card border-border/30">
-              <CardHeader>
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <Users className="h-4 w-4 text-primary" />
-                  Clientes
-                </CardTitle>
-                <CardDescription>Agrega clientes para registrar ventas.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <Input placeholder="Nombre" value={clienteForm.nombre} onChange={(e) => setClienteForm({ ...clienteForm, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
-                  <Input placeholder="Apellido" value={clienteForm.apellido} onChange={(e) => setClienteForm({ ...clienteForm, apellido: e.target.value })} className="bg-secondary/50 border-border/30" />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <Input placeholder="Correo" value={clienteForm.correo} onChange={(e) => setClienteForm({ ...clienteForm, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
-                  <Input placeholder="Telefono" value={clienteForm.telefono} onChange={(e) => setClienteForm({ ...clienteForm, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
-                </div>
-                <Button onClick={handleAddCliente} disabled={savingTerceros || !clienteForm.nombre.trim()}>
-                  {savingTerceros && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
-                  Agregar Cliente
-                </Button>
-                <Separator className="bg-border/30" />
-                <div className="max-h-44 overflow-y-auto space-y-2">
-                  {clientes.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">Aun no hay clientes registrados.</p>
-                  ) : clientes.map((c: { id: string; nombre: string; apellido?: string }) => (
-                    <div key={c.id} className="text-sm text-foreground">{c.nombre} {c.apellido || ""}</div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="glass-card border-border/30">
-              <CardHeader>
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <Truck className="h-4 w-4 text-primary" />
-                  Proveedores
-                </CardTitle>
-                <CardDescription>Agrega proveedores para registrar compras.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <Input placeholder="Nombre" value={proveedorForm.nombre} onChange={(e) => setProveedorForm({ ...proveedorForm, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
-                <div className="grid grid-cols-2 gap-3">
-                  <Input placeholder="Correo" value={proveedorForm.correo} onChange={(e) => setProveedorForm({ ...proveedorForm, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
-                  <Input placeholder="Telefono" value={proveedorForm.telefono} onChange={(e) => setProveedorForm({ ...proveedorForm, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
-                </div>
-                <Button onClick={handleAddProveedor} disabled={savingTerceros || !proveedorForm.nombre.trim()}>
-                  {savingTerceros && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
-                  Agregar Proveedor
-                </Button>
-                <Separator className="bg-border/30" />
-                <div className="max-h-44 overflow-y-auto space-y-2">
-                  {proveedores.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">Aun no hay proveedores registrados.</p>
-                  ) : proveedores.map((p: { id: string; nombre: string }) => (
-                    <div key={p.id} className="text-sm text-foreground">{p.nombre}</div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/app/dashboard/configuracion/page.tsx
+++ b/app/dashboard/configuracion/page.tsx
@@ -9,6 +9,8 @@ import {
   Loader2,
   AlertTriangle,
   CheckCircle,
+  Users,
+  Truck,
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -25,6 +27,8 @@ export default function ConfiguracionPage() {
   const [saveStatus, setSaveStatus] = useState<{ success: boolean; message: string } | null>(null)
 
   const { data, error, isLoading } = useSWR("/api/empresa", fetcher)
+  const { data: clientesData } = useSWR("/api/clientes", fetcher)
+  const { data: proveedoresData } = useSWR("/api/proveedores", fetcher)
 
   const [formData, setFormData] = useState({
     nombre: "",
@@ -32,6 +36,9 @@ export default function ConfiguracionPage() {
     direccion: "",
     id_fiscal: "",
   })
+  const [clienteForm, setClienteForm] = useState({ nombre: "", apellido: "", correo: "", telefono: "" })
+  const [proveedorForm, setProveedorForm] = useState({ nombre: "", correo: "", telefono: "" })
+  const [savingTerceros, setSavingTerceros] = useState(false)
 
   useEffect(() => {
     if (data?.empresa) {
@@ -74,6 +81,46 @@ export default function ConfiguracionPage() {
       setSaving(false)
     }
   }
+
+
+  const handleAddCliente = async () => {
+    if (!clienteForm.nombre.trim()) return
+    setSavingTerceros(true)
+    try {
+      const res = await fetch("/api/clientes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(clienteForm),
+      })
+      if (res.ok) {
+        setClienteForm({ nombre: "", apellido: "", correo: "", telefono: "" })
+        mutate("/api/clientes")
+      }
+    } finally {
+      setSavingTerceros(false)
+    }
+  }
+
+  const handleAddProveedor = async () => {
+    if (!proveedorForm.nombre.trim()) return
+    setSavingTerceros(true)
+    try {
+      const res = await fetch("/api/proveedores", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(proveedorForm),
+      })
+      if (res.ok) {
+        setProveedorForm({ nombre: "", correo: "", telefono: "" })
+        mutate("/api/proveedores")
+      }
+    } finally {
+      setSavingTerceros(false)
+    }
+  }
+
+  const clientes = clientesData?.clientes || []
+  const proveedores = proveedoresData?.proveedores || []
 
   if (isLoading) {
     return (
@@ -120,6 +167,10 @@ export default function ConfiguracionPage() {
           <TabsTrigger value="seguridad" className="text-xs gap-1.5 data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
             <Shield className="h-3.5 w-3.5" />
             Seguridad
+          </TabsTrigger>
+          <TabsTrigger value="terceros" className="text-xs gap-1.5 data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
+            <Users className="h-3.5 w-3.5" />
+            Clientes/Proveedores
           </TabsTrigger>
         </TabsList>
 
@@ -275,6 +326,72 @@ export default function ConfiguracionPage() {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+
+        <TabsContent value="terceros" className="mt-6">
+          <div className="grid lg:grid-cols-2 gap-6">
+            <Card className="glass-card border-border/30">
+              <CardHeader>
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Users className="h-4 w-4 text-primary" />
+                  Clientes
+                </CardTitle>
+                <CardDescription>Agrega clientes para registrar ventas.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <Input placeholder="Nombre" value={clienteForm.nombre} onChange={(e) => setClienteForm({ ...clienteForm, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
+                  <Input placeholder="Apellido" value={clienteForm.apellido} onChange={(e) => setClienteForm({ ...clienteForm, apellido: e.target.value })} className="bg-secondary/50 border-border/30" />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Input placeholder="Correo" value={clienteForm.correo} onChange={(e) => setClienteForm({ ...clienteForm, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
+                  <Input placeholder="Telefono" value={clienteForm.telefono} onChange={(e) => setClienteForm({ ...clienteForm, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
+                </div>
+                <Button onClick={handleAddCliente} disabled={savingTerceros || !clienteForm.nombre.trim()}>
+                  {savingTerceros && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                  Agregar Cliente
+                </Button>
+                <Separator className="bg-border/30" />
+                <div className="max-h-44 overflow-y-auto space-y-2">
+                  {clientes.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">Aun no hay clientes registrados.</p>
+                  ) : clientes.map((c: { id: string; nombre: string; apellido?: string }) => (
+                    <div key={c.id} className="text-sm text-foreground">{c.nombre} {c.apellido || ""}</div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="glass-card border-border/30">
+              <CardHeader>
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Truck className="h-4 w-4 text-primary" />
+                  Proveedores
+                </CardTitle>
+                <CardDescription>Agrega proveedores para registrar compras.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Input placeholder="Nombre" value={proveedorForm.nombre} onChange={(e) => setProveedorForm({ ...proveedorForm, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
+                <div className="grid grid-cols-2 gap-3">
+                  <Input placeholder="Correo" value={proveedorForm.correo} onChange={(e) => setProveedorForm({ ...proveedorForm, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
+                  <Input placeholder="Telefono" value={proveedorForm.telefono} onChange={(e) => setProveedorForm({ ...proveedorForm, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
+                </div>
+                <Button onClick={handleAddProveedor} disabled={savingTerceros || !proveedorForm.nombre.trim()}>
+                  {savingTerceros && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                  Agregar Proveedor
+                </Button>
+                <Separator className="bg-border/30" />
+                <div className="max-h-44 overflow-y-auto space-y-2">
+                  {proveedores.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">Aun no hay proveedores registrados.</p>
+                  ) : proveedores.map((p: { id: string; nombre: string }) => (
+                    <div key={p.id} className="text-sm text-foreground">{p.nombre}</div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/app/dashboard/movimientos/page.tsx
+++ b/app/dashboard/movimientos/page.tsx
@@ -8,40 +8,19 @@ import {
   ArrowUpRight,
   Calendar,
   Download,
-  Plus,
+  ShoppingCart,
+  Truck,
   Loader2,
   AlertTriangle,
 } from "lucide-react"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
 
 interface Movimiento {
   id: string
@@ -53,6 +32,8 @@ interface Movimiento {
   stock_antes: number
   stock_despues: number
   motivo: string | null
+  id_venta?: string | null
+  id_compra?: string | null
 }
 
 interface Producto {
@@ -60,6 +41,19 @@ interface Producto {
   nombre: string
   sku: string | null
   stock: number
+  precio_costo: number
+  precio_venta: number
+}
+
+interface Cliente {
+  id: string
+  nombre: string
+  apellido: string | null
+}
+
+interface Proveedor {
+  id: string
+  nombre: string
 }
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
@@ -79,313 +73,148 @@ function formatMovementType(tipo: string) {
 export default function MovimientosPage() {
   const [tipo, setTipo] = useState("todos")
   const [periodo, setPeriodo] = useState("30d")
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [formData, setFormData] = useState({
-    id_producto: "",
-    tipo: "entrada",
-    cantidad: "",
-    motivo: "",
-  })
+  const [compraOpen, setCompraOpen] = useState(false)
+  const [ventaOpen, setVentaOpen] = useState(false)
+  const [savingCompra, setSavingCompra] = useState(false)
+  const [savingVenta, setSavingVenta] = useState(false)
+  const [compraForm, setCompraForm] = useState({ id_proveedor: "", id_producto: "", cantidad: "", precio_unitario: "" })
+  const [ventaForm, setVentaForm] = useState({ id_cliente: "", id_producto: "", cantidad: "", precio_unitario: "" })
 
   const apiUrl = `/api/movimientos?tipo=${tipo}&periodo=${periodo}`
   const { data, error, isLoading } = useSWR(apiUrl, fetcher, { refreshInterval: 15000 })
   const { data: prodData } = useSWR("/api/productos", fetcher)
+  const { data: clientesData } = useSWR("/api/clientes", fetcher)
+  const { data: proveedoresData } = useSWR("/api/proveedores", fetcher)
 
   const movimientos: Movimiento[] = data?.movimientos || []
   const stats = data?.stats || { entradas: 0, salidas: 0, neto: 0, total: 0 }
   const productos: Producto[] = prodData?.productos || []
+  const clientes: Cliente[] = clientesData?.clientes || []
+  const proveedores: Proveedor[] = proveedoresData?.proveedores || []
 
   const handleExportCSV = () => {
     window.open(`/api/movimientos?tipo=${tipo}&periodo=${periodo}&export=csv`, "_blank")
   }
 
-  const handleSubmit = async () => {
-    if (!formData.id_producto || !formData.cantidad) return
-    setSaving(true)
-
+  const handleCompra = async () => {
+    if (!compraForm.id_proveedor || !compraForm.id_producto || !compraForm.cantidad || !compraForm.precio_unitario) return
+    setSavingCompra(true)
     try {
-      const res = await fetch("/api/movimientos", {
+      const res = await fetch("/api/compras", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({
+          id_proveedor: compraForm.id_proveedor,
+          items: [{ id_producto: compraForm.id_producto, cantidad: Number(compraForm.cantidad), precio_unitario: Number(compraForm.precio_unitario) }],
+        }),
       })
-
       if (res.ok) {
         mutate(apiUrl)
         mutate("/api/productos")
-        setDialogOpen(false)
-        setFormData({ id_producto: "", tipo: "entrada", cantidad: "", motivo: "" })
+        setCompraOpen(false)
+        setCompraForm({ id_proveedor: "", id_producto: "", cantidad: "", precio_unitario: "" })
       }
-    } catch (err) {
-      console.error("Error creating movement:", err)
     } finally {
-      setSaving(false)
+      setSavingCompra(false)
     }
   }
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
-          <p className="text-sm text-muted-foreground">Cargando movimientos...</p>
-        </div>
-      </div>
-    )
+  const handleVenta = async () => {
+    if (!ventaForm.id_cliente || !ventaForm.id_producto || !ventaForm.cantidad || !ventaForm.precio_unitario) return
+    setSavingVenta(true)
+    try {
+      const res = await fetch("/api/ventas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id_cliente: ventaForm.id_cliente,
+          items: [{ id_producto: ventaForm.id_producto, cantidad: Number(ventaForm.cantidad), precio_unitario: Number(ventaForm.precio_unitario) }],
+        }),
+      })
+      if (res.ok) {
+        mutate(apiUrl)
+        mutate("/api/productos")
+        setVentaOpen(false)
+        setVentaForm({ id_cliente: "", id_producto: "", cantidad: "", precio_unitario: "" })
+      }
+    } finally {
+      setSavingVenta(false)
+    }
   }
 
-  if (error || data?.error) {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <AlertTriangle className="h-8 w-8 text-amber-400" />
-          <p className="text-sm text-muted-foreground">Error al cargar movimientos</p>
-        </div>
-      </div>
-    )
-  }
+  if (isLoading) return <div className="flex items-center justify-center min-h-[60vh]"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>
+  if (error || data?.error) return <div className="flex items-center justify-center min-h-[60vh]"><AlertTriangle className="h-8 w-8 text-amber-400" /></div>
 
   return (
     <div className="flex flex-col gap-6 animate-fade-in">
-      {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Movimientos</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Historial de entradas y salidas de inventario.
-          </p>
+          <p className="text-sm text-muted-foreground mt-1">El inventario solo cambia por compras y ventas (no por ajustes manuales).</p>
         </div>
         <div className="flex items-center gap-2">
-          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-            <DialogTrigger asChild>
-              <Button className="bg-primary text-primary-foreground hover:bg-primary/90 gap-2">
-                <Plus className="h-4 w-4" />
-                Nuevo Movimiento
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="glass-card border-border/30 sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Registrar Movimiento</DialogTitle>
-                <DialogDescription>
-                  Agrega una entrada o salida de inventario.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label className="text-xs">Producto</Label>
-                  <Select
-                    value={formData.id_producto}
-                    onValueChange={(val) => setFormData({ ...formData, id_producto: val })}
-                  >
-                    <SelectTrigger className="bg-secondary/50 border-border/30">
-                      <SelectValue placeholder="Seleccionar producto" />
-                    </SelectTrigger>
-                    <SelectContent className="glass-card border-border/30 max-h-60">
-                      {productos.map((p) => (
-                        <SelectItem key={p.id} value={p.id}>
-                          {p.nombre} {p.sku ? `(${p.sku})` : ""} - Stock: {p.stock}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label className="text-xs">Tipo</Label>
-                    <Select
-                      value={formData.tipo}
-                      onValueChange={(val) => setFormData({ ...formData, tipo: val })}
-                    >
-                      <SelectTrigger className="bg-secondary/50 border-border/30">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent className="glass-card border-border/30">
-                        <SelectItem value="entrada">Entrada</SelectItem>
-                        <SelectItem value="salida">Salida</SelectItem>
-                        <SelectItem value="ajuste_positivo">Ajuste +</SelectItem>
-                        <SelectItem value="ajuste_negativo">Ajuste -</SelectItem>
-                        <SelectItem value="devolucion_venta">Dev. Venta</SelectItem>
-                        <SelectItem value="devolucion_compra">Dev. Compra</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="grid gap-2">
-                    <Label className="text-xs">Cantidad</Label>
-                    <Input
-                      type="number"
-                      min="1"
-                      value={formData.cantidad}
-                      onChange={(e) => setFormData({ ...formData, cantidad: e.target.value })}
-                      className="bg-secondary/50 border-border/30"
-                      placeholder="0"
-                    />
-                  </div>
-                </div>
-                <div className="grid gap-2">
-                  <Label className="text-xs">Motivo (opcional)</Label>
-                  <Textarea
-                    value={formData.motivo}
-                    onChange={(e) => setFormData({ ...formData, motivo: e.target.value })}
-                    className="bg-secondary/50 border-border/30 min-h-[80px]"
-                    placeholder="Ej: Reabastecimiento semanal"
-                  />
+          <Dialog open={compraOpen} onOpenChange={setCompraOpen}>
+            <DialogTrigger asChild><Button className="gap-2"><Truck className="h-4 w-4" />Registrar Compra</Button></DialogTrigger>
+            <DialogContent>
+              <DialogHeader><DialogTitle>Nueva compra</DialogTitle><DialogDescription>Debes seleccionar proveedor y producto.</DialogDescription></DialogHeader>
+              <div className="grid gap-3">
+                <Label>Proveedor</Label>
+                <Select value={compraForm.id_proveedor} onValueChange={(v) => setCompraForm({ ...compraForm, id_proveedor: v })}><SelectTrigger><SelectValue placeholder="Seleccionar" /></SelectTrigger><SelectContent>{proveedores.map((p) => <SelectItem key={p.id} value={p.id}>{p.nombre}</SelectItem>)}</SelectContent></Select>
+                <Label>Producto</Label>
+                <Select value={compraForm.id_producto} onValueChange={(v) => setCompraForm({ ...compraForm, id_producto: v })}><SelectTrigger><SelectValue placeholder="Seleccionar" /></SelectTrigger><SelectContent>{productos.map((p) => <SelectItem key={p.id} value={p.id}>{p.nombre}</SelectItem>)}</SelectContent></Select>
+                <div className="grid grid-cols-2 gap-3">
+                  <div><Label>Cantidad</Label><Input type="number" min="1" value={compraForm.cantidad} onChange={(e) => setCompraForm({ ...compraForm, cantidad: e.target.value })} /></div>
+                  <div><Label>Precio</Label><Input type="number" min="0" value={compraForm.precio_unitario} onChange={(e) => setCompraForm({ ...compraForm, precio_unitario: e.target.value })} /></div>
                 </div>
               </div>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setDialogOpen(false)} className="border-border/30">
-                  Cancelar
-                </Button>
-                <Button
-                  className="bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={handleSubmit}
-                  disabled={saving || !formData.id_producto || !formData.cantidad}
-                >
-                  {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-                  Registrar
-                </Button>
-              </DialogFooter>
+              <DialogFooter><Button onClick={handleCompra} disabled={savingCompra || !compraForm.id_proveedor || !compraForm.id_producto || !compraForm.cantidad || !compraForm.precio_unitario}>{savingCompra ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}Guardar compra</Button></DialogFooter>
             </DialogContent>
           </Dialog>
-          <Button variant="outline" className="border-border/30 gap-2 text-sm" onClick={handleExportCSV}>
-            <Download className="h-4 w-4" />
-            Exportar CSV
-          </Button>
+
+          <Dialog open={ventaOpen} onOpenChange={setVentaOpen}>
+            <DialogTrigger asChild><Button variant="outline" className="gap-2"><ShoppingCart className="h-4 w-4" />Registrar Venta</Button></DialogTrigger>
+            <DialogContent>
+              <DialogHeader><DialogTitle>Nueva venta</DialogTitle><DialogDescription>Debes seleccionar cliente y producto.</DialogDescription></DialogHeader>
+              <div className="grid gap-3">
+                <Label>Cliente</Label>
+                <Select value={ventaForm.id_cliente} onValueChange={(v) => setVentaForm({ ...ventaForm, id_cliente: v })}><SelectTrigger><SelectValue placeholder="Seleccionar" /></SelectTrigger><SelectContent>{clientes.map((c) => <SelectItem key={c.id} value={c.id}>{c.nombre} {c.apellido || ""}</SelectItem>)}</SelectContent></Select>
+                <Label>Producto</Label>
+                <Select value={ventaForm.id_producto} onValueChange={(v) => setVentaForm({ ...ventaForm, id_producto: v })}><SelectTrigger><SelectValue placeholder="Seleccionar" /></SelectTrigger><SelectContent>{productos.map((p) => <SelectItem key={p.id} value={p.id}>{p.nombre} · Stock {p.stock}</SelectItem>)}</SelectContent></Select>
+                <div className="grid grid-cols-2 gap-3">
+                  <div><Label>Cantidad</Label><Input type="number" min="1" value={ventaForm.cantidad} onChange={(e) => setVentaForm({ ...ventaForm, cantidad: e.target.value })} /></div>
+                  <div><Label>Precio</Label><Input type="number" min="0" value={ventaForm.precio_unitario} onChange={(e) => setVentaForm({ ...ventaForm, precio_unitario: e.target.value })} /></div>
+                </div>
+              </div>
+              <DialogFooter><Button onClick={handleVenta} disabled={savingVenta || !ventaForm.id_cliente || !ventaForm.id_producto || !ventaForm.cantidad || !ventaForm.precio_unitario}>{savingVenta ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}Guardar venta</Button></DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Button variant="outline" className="border-border/30 gap-2 text-sm" onClick={handleExportCSV}><Download className="h-4 w-4" />Exportar CSV</Button>
         </div>
       </div>
 
-      {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <Card className="glass-card border-border/30">
-          <CardContent className="pt-0">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-500/10">
-                <ArrowDownLeft className="h-5 w-5 text-green-400" />
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">Entradas</p>
-                <p className="text-xl font-bold text-foreground">{stats.entradas.toLocaleString()}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="glass-card border-border/30">
-          <CardContent className="pt-0">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-red-500/10">
-                <ArrowUpRight className="h-5 w-5 text-red-400" />
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">Salidas</p>
-                <p className="text-xl font-bold text-foreground">{stats.salidas.toLocaleString()}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="glass-card border-border/30">
-          <CardContent className="pt-0">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-                <ArrowLeftRight className="h-5 w-5 text-primary" />
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">Neto</p>
-                <p className="text-xl font-bold text-foreground">
-                  {stats.neto >= 0 ? "+" : ""}{stats.neto.toLocaleString()}
-                </p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <Card><CardContent className="pt-0"><div className="flex items-center gap-3"><ArrowDownLeft className="h-5 w-5 text-green-400" /><div><p className="text-xs text-muted-foreground">Entradas</p><p className="text-xl font-bold text-foreground">{stats.entradas.toLocaleString()}</p></div></div></CardContent></Card>
+        <Card><CardContent className="pt-0"><div className="flex items-center gap-3"><ArrowUpRight className="h-5 w-5 text-red-400" /><div><p className="text-xs text-muted-foreground">Salidas</p><p className="text-xl font-bold text-foreground">{stats.salidas.toLocaleString()}</p></div></div></CardContent></Card>
+        <Card><CardContent className="pt-0"><div className="flex items-center gap-3"><ArrowLeftRight className="h-5 w-5 text-primary" /><div><p className="text-xs text-muted-foreground">Neto</p><p className="text-xl font-bold text-foreground">{stats.neto >= 0 ? "+" : ""}{stats.neto.toLocaleString()}</p></div></div></CardContent></Card>
       </div>
 
-      {/* Filters */}
       <div className="flex items-center gap-3">
-        <Select value={tipo} onValueChange={setTipo}>
-          <SelectTrigger className="w-36 bg-secondary/50 border-border/30 text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent className="glass-card border-border/30">
-            <SelectItem value="todos">Todos</SelectItem>
-            <SelectItem value="entradas">Entradas</SelectItem>
-            <SelectItem value="salidas">Salidas</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select value={periodo} onValueChange={setPeriodo}>
-          <SelectTrigger className="w-40 bg-secondary/50 border-border/30 text-sm">
-            <Calendar className="h-3.5 w-3.5 mr-1" />
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent className="glass-card border-border/30">
-            <SelectItem value="1d">Hoy</SelectItem>
-            <SelectItem value="7d">Ultimos 7 dias</SelectItem>
-            <SelectItem value="30d">Ultimos 30 dias</SelectItem>
-            <SelectItem value="all">Todos</SelectItem>
-          </SelectContent>
-        </Select>
+        <Select value={tipo} onValueChange={setTipo}><SelectTrigger className="w-36"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="todos">Todos</SelectItem><SelectItem value="entradas">Entradas</SelectItem><SelectItem value="salidas">Salidas</SelectItem></SelectContent></Select>
+        <Select value={periodo} onValueChange={setPeriodo}><SelectTrigger className="w-40"><Calendar className="h-3.5 w-3.5 mr-1" /><SelectValue /></SelectTrigger><SelectContent><SelectItem value="1d">Hoy</SelectItem><SelectItem value="7d">Últimos 7 días</SelectItem><SelectItem value="30d">Últimos 30 días</SelectItem></SelectContent></Select>
       </div>
 
-      {/* Table */}
-      <Card className="glass-card border-border/30">
-        <CardContent className="pt-6">
-          {movimientos.length > 0 ? (
-            <Table>
-              <TableHeader>
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableHead className="text-xs">Producto</TableHead>
-                  <TableHead className="text-xs">Tipo</TableHead>
-                  <TableHead className="text-xs text-right">Cantidad</TableHead>
-                  <TableHead className="text-xs text-right">Stock</TableHead>
-                  <TableHead className="text-xs">Fecha</TableHead>
-                  <TableHead className="text-xs">Motivo</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {movimientos.map((mov) => {
-                  const movType = formatMovementType(mov.tipo)
-                  return (
-                    <TableRow key={mov.id} className="border-border/20">
-                      <TableCell className="text-xs text-foreground font-medium">
-                        {mov.producto}
-                        {mov.sku && <span className="text-muted-foreground ml-1">({mov.sku})</span>}
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="secondary"
-                          className={`text-[10px] ${
-                            movType.variant === "entrada"
-                              ? "bg-green-500/10 text-green-400 border-green-500/20"
-                              : "bg-red-500/10 text-red-400 border-red-500/20"
-                          }`}
-                        >
-                          {movType.label}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-xs text-right text-foreground">{mov.cantidad}</TableCell>
-                      <TableCell className="text-xs text-right text-muted-foreground">
-                        {mov.stock_antes} → {mov.stock_despues}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {new Date(mov.creado_en).toLocaleDateString("es-CR", {
-                          day: "numeric",
-                          month: "short",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground max-w-[150px] truncate">
-                        {mov.motivo || "—"}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          ) : (
-            <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
-              No hay movimientos registrados en este periodo.
-            </div>
-          )}
+      <Card>
+        <CardContent className="pt-0">
+          <Table>
+            <TableHeader><TableRow><TableHead>Fecha</TableHead><TableHead>Producto</TableHead><TableHead>Tipo</TableHead><TableHead>Cantidad</TableHead><TableHead>Stock</TableHead><TableHead>Documento</TableHead></TableRow></TableHeader>
+            <TableBody>
+              {movimientos.length === 0 ? <TableRow><TableCell colSpan={6} className="text-center text-muted-foreground">No hay movimientos para mostrar</TableCell></TableRow> : movimientos.map((m) => {
+                const typeInfo = formatMovementType(m.tipo)
+                return <TableRow key={m.id}><TableCell>{new Date(m.creado_en).toLocaleString("es-CR")}</TableCell><TableCell>{m.producto}</TableCell><TableCell><Badge variant={typeInfo.variant === "entrada" ? "default" : "destructive"}>{typeInfo.label}</Badge></TableCell><TableCell>{m.cantidad}</TableCell><TableCell>{m.stock_antes} → {m.stock_despues}</TableCell><TableCell>{m.id_compra ? `Compra ${m.id_compra.slice(0, 8)}` : m.id_venta ? `Venta ${m.id_venta.slice(0, 8)}` : "-"}</TableCell></TableRow>
+              })}
+            </TableBody>
+          </Table>
         </CardContent>
       </Card>
     </div>

--- a/app/dashboard/productos/page.tsx
+++ b/app/dashboard/productos/page.tsx
@@ -85,7 +85,6 @@ export default function ProductosPage() {
     nombre: "",
     sku: "",
     id_categoria: "",
-    stock: "0",
     stock_minimo: "0",
     precio_costo: "0",
     precio_venta: "0",
@@ -103,8 +102,7 @@ export default function ProductosPage() {
       nombre: "",
       sku: "",
       id_categoria: "",
-      stock: "0",
-      stock_minimo: "0",
+        stock_minimo: "0",
       precio_costo: "0",
       precio_venta: "0",
     })
@@ -117,7 +115,6 @@ export default function ProductosPage() {
       nombre: product.nombre,
       sku: product.sku || "",
       id_categoria: product.id_categoria || "",
-      stock: product.stock.toString(),
       stock_minimo: product.stock_minimo.toString(),
       precio_costo: product.precio_costo.toString(),
       precio_venta: product.precio_venta.toString(),
@@ -251,28 +248,15 @@ export default function ProductosPage() {
                   </Select>
                 </div>
               </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="stock" className="text-xs">Stock Inicial</Label>
-                  <Input
-                    id="stock"
-                    type="number"
-                    value={formData.stock}
-                    onChange={(e) => setFormData({ ...formData, stock: e.target.value })}
-                    className="bg-secondary/50 border-border/30"
-                    disabled={!!editingProduct}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="min" className="text-xs">Stock Minimo</Label>
-                  <Input
-                    id="min"
-                    type="number"
-                    value={formData.stock_minimo}
-                    onChange={(e) => setFormData({ ...formData, stock_minimo: e.target.value })}
-                    className="bg-secondary/50 border-border/30"
-                  />
-                </div>
+              <div className="grid gap-2">
+                <Label htmlFor="min" className="text-xs">Stock Minimo</Label>
+                <Input
+                  id="min"
+                  type="number"
+                  value={formData.stock_minimo}
+                  onChange={(e) => setFormData({ ...formData, stock_minimo: e.target.value })}
+                  className="bg-secondary/50 border-border/30"
+                />
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="grid gap-2">

--- a/app/dashboard/productos/page.tsx
+++ b/app/dashboard/productos/page.tsx
@@ -54,6 +54,11 @@ interface Categoria {
   nombre: string
 }
 
+interface Proveedor {
+  id: string
+  nombre: string
+}
+
 interface Producto {
   id: string
   nombre: string
@@ -88,14 +93,19 @@ export default function ProductosPage() {
     stock_minimo: "0",
     precio_costo: "0",
     precio_venta: "0",
+    cantidad_inicial: "0",
+    id_proveedor: "",
+    precio_compra: "0",
   })
 
   const apiUrl = `/api/productos?search=${encodeURIComponent(searchQuery)}&categoria=${selectedCategory}`
   const { data, error, isLoading } = useSWR(apiUrl, fetcher, { refreshInterval: 30000 })
   const { data: catData } = useSWR("/api/categorias", fetcher)
+  const { data: provData } = useSWR("/api/proveedores", fetcher)
 
   const productos: Producto[] = data?.productos || []
   const categorias: Categoria[] = catData?.categorias || []
+  const proveedores: Proveedor[] = provData?.proveedores || []
 
   const resetForm = () => {
     setFormData({
@@ -105,6 +115,9 @@ export default function ProductosPage() {
         stock_minimo: "0",
       precio_costo: "0",
       precio_venta: "0",
+      cantidad_inicial: "0",
+      id_proveedor: "",
+      precio_compra: "0",
     })
     setEditingProduct(null)
   }
@@ -118,6 +131,9 @@ export default function ProductosPage() {
       stock_minimo: product.stock_minimo.toString(),
       precio_costo: product.precio_costo.toString(),
       precio_venta: product.precio_venta.toString(),
+      cantidad_inicial: "0",
+      id_proveedor: "",
+      precio_compra: product.precio_costo.toString(),
     })
     setDialogOpen(true)
   }
@@ -258,6 +274,49 @@ export default function ProductosPage() {
                   className="bg-secondary/50 border-border/30"
                 />
               </div>
+
+              {!editingProduct && (
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor="cantidad-inicial" className="text-xs">Cantidad Inicial</Label>
+                    <Input
+                      id="cantidad-inicial"
+                      type="number"
+                      min="0"
+                      value={formData.cantidad_inicial}
+                      onChange={(e) => setFormData({ ...formData, cantidad_inicial: e.target.value })}
+                      className="bg-secondary/50 border-border/30"
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label className="text-xs">Proveedor</Label>
+                    <Select
+                      value={formData.id_proveedor}
+                      onValueChange={(val) => setFormData({ ...formData, id_proveedor: val })}
+                    >
+                      <SelectTrigger className="bg-secondary/50 border-border/30">
+                        <SelectValue placeholder="Seleccionar" />
+                      </SelectTrigger>
+                      <SelectContent className="glass-card border-border/30">
+                        {proveedores.map((prov) => (
+                          <SelectItem key={prov.id} value={prov.id}>{prov.nombre}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="precio-compra" className="text-xs">Precio Compra</Label>
+                    <Input
+                      id="precio-compra"
+                      type="number"
+                      min="0"
+                      value={formData.precio_compra}
+                      onChange={(e) => setFormData({ ...formData, precio_compra: e.target.value })}
+                      className="bg-secondary/50 border-border/30"
+                    />
+                  </div>
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-4">
                 <div className="grid gap-2">
                   <Label htmlFor="costo" className="text-xs">Precio Costo</Label>
@@ -288,7 +347,7 @@ export default function ProductosPage() {
               <Button
                 className="bg-primary text-primary-foreground hover:bg-primary/90"
                 onClick={handleSubmit}
-                disabled={saving || !formData.nombre.trim()}
+                disabled={saving || !formData.nombre.trim() || (!editingProduct && Number(formData.cantidad_inicial) > 0 && !formData.id_proveedor)}
               >
                 {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
                 {editingProduct ? "Guardar Cambios" : "Guardar Producto"}

--- a/app/dashboard/proveedores/page.tsx
+++ b/app/dashboard/proveedores/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState } from "react"
+import useSWR, { mutate } from "swr"
+import { Truck, Loader2, AlertTriangle, Plus } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+export default function ProveedoresPage() {
+  const { data, error, isLoading } = useSWR("/api/proveedores", fetcher)
+  const [saving, setSaving] = useState(false)
+  const [form, setForm] = useState({ nombre: "", correo: "", telefono: "" })
+
+  const proveedores = data?.proveedores || []
+
+  const handleSave = async () => {
+    if (!form.nombre.trim()) return
+    setSaving(true)
+    try {
+      const res = await fetch("/api/proveedores", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      })
+      if (res.ok) {
+        setForm({ nombre: "", correo: "", telefono: "" })
+        mutate("/api/proveedores")
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (isLoading) return <div className="flex items-center justify-center min-h-[60vh]"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>
+  if (error || data?.error) return <div className="flex items-center justify-center min-h-[60vh]"><AlertTriangle className="h-8 w-8 text-amber-400" /></div>
+
+  return (
+    <div className="flex flex-col gap-6 animate-fade-in">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Proveedores</h1>
+        <p className="text-sm text-muted-foreground mt-1">Gestiona tus proveedores para registrar compras.</p>
+      </div>
+
+      <Card className="glass-card border-border/30">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2"><Plus className="h-4 w-4 text-primary" />Nuevo Proveedor</CardTitle>
+          <CardDescription>Completa los datos básicos del proveedor.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          <Input placeholder="Nombre" value={form.nombre} onChange={(e) => setForm({ ...form, nombre: e.target.value })} className="bg-secondary/50 border-border/30" />
+          <div className="grid md:grid-cols-2 gap-3">
+            <Input placeholder="Correo" value={form.correo} onChange={(e) => setForm({ ...form, correo: e.target.value })} className="bg-secondary/50 border-border/30" />
+            <Input placeholder="Teléfono" value={form.telefono} onChange={(e) => setForm({ ...form, telefono: e.target.value })} className="bg-secondary/50 border-border/30" />
+          </div>
+          <Button onClick={handleSave} disabled={saving || !form.nombre.trim()} className="w-fit">
+            {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            Guardar Proveedor
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="glass-card border-border/30">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2"><Truck className="h-4 w-4 text-primary" />Listado de Proveedores</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {proveedores.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Aún no hay proveedores registrados.</p>
+            ) : proveedores.map((p: { id: string; nombre: string; correo?: string; telefono?: string }) => (
+              <div key={p.id} className="rounded-md border border-border/30 p-3 text-sm">
+                <p className="font-medium">{p.nombre}</p>
+                <p className="text-muted-foreground">{p.correo || "Sin correo"} · {p.telefono || "Sin teléfono"}</p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/dashboard/sidebar.tsx
+++ b/components/dashboard/sidebar.tsx
@@ -7,6 +7,8 @@ import Image from "next/image"
 import {
   LayoutDashboard,
   Package,
+  Users,
+  Truck,
   BarChart3,
   ArrowLeftRight,
   Bell,
@@ -31,6 +33,8 @@ import { createClient } from "@/lib/supabase/client"
 const sidebarLinks = [
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Productos", href: "/dashboard/productos", icon: Package },
+  { label: "Clientes", href: "/dashboard/clientes", icon: Users },
+  { label: "Proveedores", href: "/dashboard/proveedores", icon: Truck },
   { label: "Movimientos", href: "/dashboard/movimientos", icon: ArrowLeftRight },
   { label: "Reportes", href: "/dashboard/reportes", icon: BarChart3 },
   { label: "Alertas", href: "/dashboard/alertas", icon: Bell, badge: 3 },


### PR DESCRIPTION
### Motivation
- Reemplazar la lógica de inventario basada en ajustes manuales por un flujo documental trazable donde las entradas provienen exclusivamente de `compra` y las salidas de `venta`, otorgando historial y análisis real para una pyme. 
- Forzar el uso de `id_empresa` en consultas y aprovechar las vistas existentes (`v_historial_inventario`, `v_productos_bajo_stock`, `v_productos_mas_vendidos`, `v_resumen_ventas_mensual`) para garantizar aislamiento multi-tenant y enriquecer dashboards. 
- Evitar modificaciones directas de `producto.stock` desde el frontend/backend fuera de los documentos (compra/venta) y asegurar validaciones mínimas en formularios (compras sin proveedor / ventas sin cliente / ventas/compras sin productos). 

### Description
- Deshabilita movimientos manuales en la API: `POST /api/movimientos` ahora responde `405` y la exportación/historial incluye referencia documental (`id_compra`/`id_venta`) en CSV. (`app/api/movimientos/route.ts`).
- Añade endpoints transaccionales y auxiliares: `GET/POST /api/compras`, `GET/POST /api/ventas`, `GET /api/clientes`, `GET /api/proveedores`, con validaciones de pertenencia a `empresa` y creación de `compra`/`compra_detalle` / `venta`/`venta_detalle` y upsert en `producto_proveedor`. (`app/api/compras/route.ts`, `app/api/ventas/route.ts`, `app/api/clientes/route.ts`, `app/api/proveedores/route.ts`).
- Cambia creación de productos para partir con `stock: 0` y elimina la inserción automática de movimiento inicial desde `POST /api/productos`, alineando el flujo para que el stock cambie solo por documentos. (`app/api/productos/route.ts`, front `app/dashboard/productos/page.tsx`).
- Actualiza APIs de dashboard/reportes/alertas para consumir vistas y ofrecer métricas fiables por `id_empresa` y usar `v_historial_inventario`, `v_productos_bajo_stock`, `v_resumen_ventas_mensual`, `v_productos_mas_vendidos`. (`app/api/dashboard/route.ts`, `app/api/reportes/route.ts`, `app/api/alertas/route.ts`).
- Refactor frontend de Movimientos para reemplazar form de movimiento manual por modales de `Registrar Compra` y `Registrar Venta` con validaciones de campos obligatorios y llamadas a los nuevos endpoints; además añade listado/documento en la tabla de movimientos. (`app/dashboard/movimientos/page.tsx`).

### Testing
- `npm run lint`: fallo por configuración de ESLint v9 ausente en el repositorio, por lo que la comprobación no pasó (no relacionado con la lógica aplicada en este PR). 
- `npm run build`: fallo durante la compilación por restricciones del entorno al descargar fuentes de Google Fonts, no por las modificaciones funcionales a las APIs. 
- `npx tsc --noEmit`: detectó errores TypeScript preexistentes en módulos no directamente modificados por este cambio; los nuevos endpoints y ajustes fueron creados y validados manualmente en código, pero la comprobación completa de tipo quedó impedida por esos errores previos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc5c486f4832796a56d620b2f57b2)